### PR TITLE
Add support for older pyOpenSSL (e.g. RHEL6)

### DIFF
--- a/requests_credssp/credssp.py
+++ b/requests_credssp/credssp.py
@@ -5,7 +5,11 @@ import struct
 try:
     from OpenSSL import SSL, _util
 except ImportError:
-    raise Exception("Cannot import pyOpenSSL")
+    try:
+        from OpenSSL import SSL
+        from OpenSSL import crypto as _util
+    except ImportError:
+        raise Exception("Cannot import pyOpenSSL")
 from ntlm_auth.ntlm import Ntlm
 from requests.auth import AuthBase
 


### PR DESCRIPTION
This is a small fix to ensure that older pyOpenSSL versions (e.g. version 0.13.1 on RHEL6) are supported out-of-the-box.