### PR TITLE
This fixes CredSSP for older OpenSSL versions

### DIFF
--- a/requests_credssp/credssp.py
+++ b/requests_credssp/credssp.py
@@ -75,7 +75,7 @@ class CredSSPContext(object):
         successfully authenticate with the server and delegate the credentials.
         """
         log.info("Starting TLS handshake process")
-        self.tls_connection = SSL.Connection(self.tls_context, sock=None)
+        self.tls_connection = SSL.Connection(self.tls_context, socket=None)
         self.tls_connection.set_connect_state()
 
         while True:

--- a/requests_credssp/credssp.py
+++ b/requests_credssp/credssp.py
@@ -75,7 +75,7 @@ class CredSSPContext(object):
         successfully authenticate with the server and delegate the credentials.
         """
         log.info("Starting TLS handshake process")
-        self.tls_connection = SSL.Connection(self.tls_context)
+        self.tls_connection = SSL.Connection(self.tls_context, sock=None)
         self.tls_connection.set_connect_state()
 
         while True:


### PR DESCRIPTION
This relates to the error message: **TypeError: Required argument 'socket' (pos 2) not found**
Which you get if you are running requests-credssp v0.0.1 on a system with an older pyOpenSSL (e.g. v13.x)

This relates to https://github.com/ansible/ansible/issues/42385

