### PR TITLE
Added Python 3.8 to testing and fix manifest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,24 @@
 language: python
 
-python:
-- 2.6
-- 2.7
-- 3.4
-- 3.5
-- 3.6
+dist: xenial
 
-# Python 3.7 requires 16.04 (Xenial), this is a hack to get that specific
-# distro running that version until I can swap the rest over officially
 matrix:
   include:
+  - python: 2.6
+    dist: trusty
+  - python: 2.7
+  - python: 3.4
+    dist: trusty
+  - python: 3.5
+    dist: trusty
+  - python: 3.6
   - python: 3.7
-    dist: xenial
-    sudo: yes
+  - python: 3.8-dev
+
+  # 3.8 is still an alpha and I'm running it to see if anything breaks but
+  # don't want it to stop the build
+  allow_failures:
+  - python: 3.8-dev
 
 install:
 - pip install --upgrade pip setuptools

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include LICENSE
+include CHANGES.md

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,4 +1,6 @@
-pytest<=3.2.5
+idna<2.8; python_version<"2.7"
+pytest==3.2.5; python_version<"2.7"
+pytest>=3.6; python_version>"2.7"
 pytest-cov
 pytest-pep8
 pycparser<=2.18; python_version<"2.7"

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,6 +2,7 @@
 universal = 1
 
 [tool:pytest]
+pep8maxlinelength = 119
 pep8ignore = tests/test_credssp.py E501
 
 [metadata]


### PR DESCRIPTION
Updates CI to include 3.8 and makes sure things run today as is.

Includes the LICENSE and changelog in the package created.

Updates the pep8 line length check to 119 to be a bit more modern.

Fixes https://github.com/jborean93/requests-credssp/issues/13