### PR TITLE
Fix invalid regex escape sequences, update ntlm context class

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,8 +1,17 @@
 # Changes
 
+## 1.1.0 (Aug 19, 2019)
+
+* Bumped `ntlm-auth` minimum version to `v1.2.0`
+* Use new NTLM context object to avoid having to base64 encode/decode the messages
+* Fix invalid regex escape sequences that have been deprecated in Python 3.8
+* Include `LICENSE` and `CHANGES.md` in the Python package manifest
+
+
 ## 1.0.2 (Nov 14, 2018)
 
 * Changed some log messages to a debug level instead of info
+
 
 ## 1.0.1 (Sep 25, 2018)
 

--- a/requests_credssp/credssp.py
+++ b/requests_credssp/credssp.py
@@ -457,7 +457,7 @@ class HttpCredSSPAuth(AuthBase):
         self.contexts[host] = context
 
         credssp_gen = context.credssp_generator()
-        credssp_regex = re.compile("CredSSP ([^,\s]*)$", re.I)
+        credssp_regex = re.compile(r"CredSSP ([^,\s]*)$", re.I)
 
         # loop through the CredSSP generator to exchange the tokens between the
         # client and the server until either an error occurs or we reached the

--- a/setup.py
+++ b/setup.py
@@ -13,11 +13,11 @@ except ImportError:
 
 setup(
     name='requests-credssp',
-    version='1.0.2',
+    version='1.1.0',
     packages=['requests_credssp'],
     install_requires=[
         "cryptography",
-        "ntlm-auth",
+        "ntlm-auth>=1.2.0",
         "six",
         "pyasn1>=0.3.1",
         "pyOpenSSL>=16.0.0",

--- a/tests/test_credssp.py
+++ b/tests/test_credssp.py
@@ -697,7 +697,7 @@ class TestHttpCredSSPAuth(object):
         assert actual == expected
 
     def test_get_credssp_token(self):
-        pattern = re.compile("CredSSP ([^,\s]*)$", re.I)
+        pattern = re.compile(r"CredSSP ([^,\s]*)$", re.I)
         response = requests.Response()
         response.headers['www-authenticate'] = "CredSSP YWJj"
         expected = b"abc"
@@ -706,7 +706,7 @@ class TestHttpCredSSPAuth(object):
         assert actual == expected
 
     def test_get_credssp_token_fail_no_header(self):
-        pattern = re.compile("CredSSP ([^,\s]*)$", re.I)
+        pattern = re.compile(r"CredSSP ([^,\s]*)$", re.I)
         response = requests.Response()
         with pytest.raises(AuthenticationException) as exc:
             HttpCredSSPAuth._get_credssp_token(response, pattern, "step 1")
@@ -714,7 +714,7 @@ class TestHttpCredSSPAuth(object):
                                  "token after step step 1 - actual ''"
 
     def test_get_credssp_token_fail_no_credssp_token(self):
-        pattern = re.compile("CredSSP ([^,\s]*)$", re.I)
+        pattern = re.compile(r"CredSSP ([^,\s]*)$", re.I)
         response = requests.Response()
         response.headers['www-authenticate'] = "NTLM YWJj"
         with pytest.raises(AuthenticationException) as exc:
@@ -967,7 +967,7 @@ class TestHttpCredSSPAuthFunctional(object):
         # SecPkgContext_StreamSizes but there is no GSSAPI/OpenSSL equivalent
         # so we need to calculate it ourselves
 
-        if re.match('^.*-GCM-[\w\d]*$', cipher_suite):
+        if re.match(r'^.*-GCM-[\w\d]*$', cipher_suite):
             # We are using GCM for the cipher suite, GCM has a fixed length of
             # 16 bytes for the TLS trailer making it easy for us
             trailer_length = 16

--- a/tests/test_spnego.py
+++ b/tests/test_spnego.py
@@ -175,18 +175,3 @@ class TestNTLMContext(object):
         # 0-4 is NTLM sig == 01 00 00 00 , 12:16 is the sequence number
         assert enc_msg[:4] == b"\x01\x00\x00\x00"
         assert enc_msg[12:16] == b"\x00\x00\x00\x00"
-
-    def test_ntlm_unwrap(self):
-        class SessionSecurityMock(object):
-            def unwrap(self, data1, data2):
-                # asserts NTLMContext actually splits the sig and data and
-                # sends them to ntlm-auth correctly
-                assert data1 == b"\xbb" * 16
-                assert data2 == b"\xaa" * 16
-
-        ntlm = NTLMContext("", "")
-        ntlm.init_context()
-        ntlm._context.session_security = SessionSecurityMock()
-
-        data = (b"\xaa" * 16) + (b"\xbb" * 16)
-        ntlm.unwrap(data)


### PR DESCRIPTION
Fixes various regex patterns that have a deprecated escape sequence. Also simplifies the ntlm-auth spnego class to use a newer context object that is less based on HTTP headers.