### PR TITLE
Fix Spnego stop iterator error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 
-dist: xenial
+dist: bionic
 
 matrix:
   include:
@@ -10,15 +10,9 @@ matrix:
   - python: 3.4
     dist: trusty
   - python: 3.5
-    dist: trusty
   - python: 3.6
   - python: 3.7
-  - python: 3.8-dev
-
-  # 3.8 is still an alpha and I'm running it to see if anything breaks but
-  # don't want it to stop the build
-  allow_failures:
-  - python: 3.8-dev
+  - python: 3.8
 
 install:
 - pip install --upgrade pip setuptools

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,10 @@
 # Changes
 
+## 1.1.1 (TBD)
+
+* Fixed `StopIterator` error when `gssapi`, `gss-ntlmssp` is installed and NTLM auth was negotiated with SPNEGO.
+
+
 ## 1.1.0 (Aug 19, 2019)
 
 * Bumped `ntlm-auth` minimum version to `v1.2.0`

--- a/requests_credssp/spnego.py
+++ b/requests_credssp/spnego.py
@@ -383,8 +383,9 @@ class GSSAPIContext(AuthContext):
 
             in_token = yield out_token
 
-        # one final step for the mechListMIC when using NTLM
-        self._context.step(in_token)
+        # one final step for the mechListMIC when using NTLM, we yield so the
+        # caller doesn't have to catch a StopIteration error.
+        yield self._context.step(in_token)
 
     def wrap(self, data):
         return self._context.wrap(data, True)[0]

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+colorama<=0.4.1; python_version=="3.4"
 idna<2.8; python_version<"2.7"
 pytest==3.2.5; python_version<"2.7"
 pytest>=3.6; python_version>"2.7"

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ except ImportError:
 
 setup(
     name='requests-credssp',
-    version='1.1.0',
+    version='1.1.1',
     packages=['requests_credssp'],
     install_requires=[
         "cryptography",
@@ -31,6 +31,7 @@ setup(
             'gssapi>=1.5.0'
         ]
     },
+    python_requires='>=2.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     author='Jordan Borean',
     author_email='jborean93@gmail.com',
     url='https://github.com/jborean93/requests-credssp',
@@ -49,5 +50,6 @@ setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,py34,py35,py36,py37
+envlist = py26,py27,py34,py35,py36,py37,py38
 
 [testenv]
 deps= -rrequirements-test.txt


### PR DESCRIPTION
Turns out when you are using the auto auth (SPNEGO), have both gsspi and gss-ntlmssp installed, and ultimately authenticate with NTLM auth in SPNEGO it will fail with a StopIteration error. This is because we call step() one more time after receiving the MIC on the final response and when after sending the final token we didn't yield anything back ending the generator.

Technically the value is None but we weren't expecting anything at this point in time.

Also ups CI to test against 3.8 and other fixes.