### PR TITLE
Fix up deprecated usage of pyspnego feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.3.1 - 2022-02-16
+
+* Fix usage of recently removed pyspnego feature
+
+
 ## 1.3.0 - 2021-10-22
 
 * Dropped Python 2.7 and 3.5, new minimum is 3.6

--- a/requests_credssp/credssp.py
+++ b/requests_credssp/credssp.py
@@ -160,7 +160,7 @@ class CredSSPContext(object):
         self._verify_public_keys(nonce, response_key, server_public_key)
 
         log.debug("Sending encrypted credentials")
-        enc_credentials = self._get_encrypted_credentials(context)
+        enc_credentials = self._get_encrypted_credentials(context, self.username, self.password)
 
         yield self.wrap(enc_credentials), "Step 5. Delegate Credentials"
 
@@ -253,7 +253,7 @@ class CredSSPContext(object):
             raise AuthenticationException("Could not verify key sent from the server, potential man in the middle "
                                           "attack")
 
-    def _get_encrypted_credentials(self, context):
+    def _get_encrypted_credentials(self, context, username, password):
         """
         [MS-CSSP] 3.1.5 Processing Events and Sequencing Rules - Step 5
         https://msdn.microsoft.com/en-us/library/cc226791.aspx
@@ -265,18 +265,18 @@ class CredSSPContext(object):
         server
 
         :param context: The authenticated security context
+        :param username: The username to encrypt.
+        :param password: The password to encrypt.
         :return: The encrypted TSRequest that contains the user's credentials
         """
         domain = u""
-        if "\\" in context.username:
-            domain, username = context.username.split('\\', 1)
-        else:
-            username = context.username
+        if "\\" in username:
+            domain, username = username.split('\\', 1)
 
         ts_password = TSPasswordCreds()
         ts_password['domainName'] = domain.encode('utf-16-le')
         ts_password['userName'] = username.encode('utf-16-le')
-        ts_password['password'] = context.password.encode('utf-16-le')
+        ts_password['password'] = password.encode('utf-16-le')
 
         ts_credentials = TSCredentials()
         ts_credentials['credType'] = ts_password.CRED_TYPE

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ with open(abs_path('README.md'), mode='rb') as fd:
 
 setup(
     name='requests-credssp',
-    version='1.3.0',
+    version='1.3.1',
     packages=['requests_credssp'],
     install_requires=[
         "cryptography",
@@ -30,8 +30,7 @@ setup(
     extras_require={
         'kerberos:sys_platform=="win32"': [],
         'kerberos:sys_platform!="win32"': [
-            'gssapi>=1.5.0',
-            'krb5',
+            'pyspnego[kerberos]',
         ]
     },
     python_requires='>=3.6',

--- a/tests/test_credssp.py
+++ b/tests/test_credssp.py
@@ -635,10 +635,6 @@ class TestCredSSPContext(object):
 
     def test_get_encrypted_credentials(self):
         class FakeContext(object):
-            def __init__(self):
-                self.username = "domain\\username"
-                self.password = "password"
-
             def wrap(self, data):
                 return WrapResult(data + (b"\x00" * 4))
 
@@ -670,7 +666,7 @@ class TestCredSSPContext(object):
                    b"\x70\x00\x61\x00\x73\x00\x73\x00" \
                    b"\x77\x00\x6f\x00\x72\x00\x64\x00" \
                    b"\x00\x00\x00\x00"
-        actual = credssp._get_encrypted_credentials(context)
+        actual = credssp._get_encrypted_credentials(context, "domain\\username", "password")
         assert actual == expected
 
 


### PR DESCRIPTION
The username and password property on the spnego context is deprecated. This PR stops using that and just pass in the username/password as needed.